### PR TITLE
(Hopefully) Improves the results of clipart by sorting by downloads and only getting top 5.

### DIFF
--- a/src/clipart.coffee
+++ b/src/clipart.coffee
@@ -3,18 +3,23 @@
 #
 # Commands:
 #   hubot clipart me <query> - Queries openclipart for <query> and returns a random result.
+#   Aliases:
+#     hubot clipart <query>
+#     hubot clip me <query>
+#     hubot clip <query>
 #
 # Author:
-#   desmondmorris
+#   Original - desmondmorris
+#   Improved by Dylan Davidson
 
 module.exports = (robot) ->
-  robot.respond /clipart(?: me)? (.*)/i, (msg) ->
+  robot.respond /(?: clip|clipart)(?: me)? (.*)/i, (msg) ->
     clipartMe msg, (url) ->
       msg.send encodeURI(url)
 
 clipartMe = (msg, cb) ->
 
-  q = query: msg.match[1]
+  q = query: msg.match[1], amount: 5, sort: 'downloads'
 
   msg.http('https://openclipart.org/search/json/')
     .query(q)


### PR DESCRIPTION
After playing around with the [Openclipart API](https://openclipart.org/developers), I decided the best way to improve the results was by sorting by downloads `sort=downloads` and limiting to the top 5 results `limit=5`.
